### PR TITLE
Update docker version to 1.10.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #
 #     docker build --rm=true -t plugins/drone-gcr .
 
-FROM rancher/docker:1.8.1
+FROM rancher/docker:1.10.0
 
 ADD drone-gcr /go/bin/
 VOLUME /var/lib/docker

--- a/main.go
+++ b/main.go
@@ -61,7 +61,7 @@ func main() {
 	vargs.Token = strings.TrimSpace(vargs.Token)
 
 	go func() {
-		args := []string{"-d"}
+		args := []string{"daemon"}
 
 		if len(vargs.Storage) != 0 {
 			args = append(args, "-s", vargs.Storage)


### PR DESCRIPTION
Beginning February 15th, 2017, GCR will deprecate and stop supporting Docker clients below version 1.9 and Docker Registry v1 API (https://cloud.google.com/container-registry/docs/support/deprecation-notices).

This updates base image to `rancher/docker:1.10.0`.
